### PR TITLE
Add Raffinert.Spec.Analyzer which helps avoid runtime errors with SpecTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 # Raffinert.Spec
 [![NuGet version (Raffinert.Spec)](https://img.shields.io/nuget/v/Raffinert.Spec.svg?style=flat-square)](https://www.nuget.org/packages/Raffinert.Spec/)
 
+
+# Raffinert.Spec
+
 `Raffinert.Spec` is a rethinking of libraries and sources such as:
 
 - [NSpecifications](https://github.com/miholler/NSpecifications)
@@ -63,28 +66,14 @@ var adaptedSpec = template.Adapt<InventoryItem>();
 
 In this example, a specification template is created for `Product`, filtering based on `Name` and `Price`. The template is then adapted to an `InventoryItem` type with matching properties.
 
-#### Implementation Details
+### **Roslyn Analyzers for Compile-Time Validation**
 
-A `SpecTemplate<TSample, TTemplate>` allows creating reusable specifications where `TTemplate` is a projection of `TSample`. The `Adapt<TN>()` method transforms the template to another type `TN` with compatible properties.
+To prevent runtime errors when using `SpecTemplate`, we provide [Roslyn Raffinert.Spec.Analyzer](https://github.com/Raffinert/Raffinert.Spec/src/Raffinert.Spec.Analyzer) that:
 
-```csharp
-public class SpecTemplate<TSample, TTemplate>
-{
-    public Expression<Func<TSample, TTemplate>> template { get; }
-    public Expression<Func<TTemplate, bool>>? expression { get; }
+- Ensure `SpecTemplate<TSample>.Adapt<TN>()` only adapts to types that contain all required members.
+- Validate that `SpecTemplate.Create(...)` uses an anonymous type projection (e.g., `p => new { p.Name }`).
 
-    public SpecTemplate(Expression<Func<TSample, TTemplate>> template, Expression<Func<TTemplate, bool>> expression)
-    {
-        this.template = template;
-        this.expression = expression;
-    }
-
-    public Spec<TN> Adapt<TN>()
-    {
-        return Spec<TN>.Create(ConvertExpression(expression));
-    }
-}
-```
+These analyzers catch issues at compile-time, improving reliability and maintainability.
 
 ### Debugging
 

--- a/Raffinert.Spec.sln
+++ b/Raffinert.Spec.sln
@@ -7,6 +7,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Raffinert.Spec", "src\Raffi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Raffinert.Spec.IntegrationTests", "tests\Raffinert.Spec.IntegrationTests\Raffinert.Spec.IntegrationTests.csproj", "{13628080-1CA4-42E1-A426-57202293ACD0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raffinert.Spec.Analyzer", "src\Raffinert.Spec.Analyzer\Raffinert.Spec.Analyzer.csproj", "{AB85F4C2-9F4D-4ACA-8493-4CDB74AD507D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raffinert.Spec.Analyzer.Test", "tests\Raffinert.Spec.Analyzer.Test\Raffinert.Spec.Analyzer.Test.csproj", "{4E8B769F-0401-4469-A47F-ED88F0615561}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{58D60380-A3B5-481D-BA63-5F9278CE1337}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,9 +27,21 @@ Global
 		{13628080-1CA4-42E1-A426-57202293ACD0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{13628080-1CA4-42E1-A426-57202293ACD0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{13628080-1CA4-42E1-A426-57202293ACD0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB85F4C2-9F4D-4ACA-8493-4CDB74AD507D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB85F4C2-9F4D-4ACA-8493-4CDB74AD507D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB85F4C2-9F4D-4ACA-8493-4CDB74AD507D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB85F4C2-9F4D-4ACA-8493-4CDB74AD507D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E8B769F-0401-4469-A47F-ED88F0615561}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E8B769F-0401-4469-A47F-ED88F0615561}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E8B769F-0401-4469-A47F-ED88F0615561}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E8B769F-0401-4469-A47F-ED88F0615561}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{13628080-1CA4-42E1-A426-57202293ACD0} = {58D60380-A3B5-481D-BA63-5F9278CE1337}
+		{4E8B769F-0401-4469-A47F-ED88F0615561} = {58D60380-A3B5-481D-BA63-5F9278CE1337}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AE424779-431F-4F22-BF55-803001BBDB26}

--- a/src/Raffinert.Spec.Analyzer/Raffinert.Spec.Analyzer.csproj
+++ b/src/Raffinert.Spec.Analyzer/Raffinert.Spec.Analyzer.csproj
@@ -1,0 +1,41 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+   <PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<NoPackageAnalysis>true</NoPackageAnalysis>
+		<IsRoslynComponent>true</IsRoslynComponent>
+		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+		<LangVersion>latest</LangVersion>
+		<Version>0.0.1</Version>
+		<Title>Readonly DbContext Generator</Title>
+		<Description>An analyzer that verifies the type signature compatibility for Specification template.</Description>
+		<Copyright>Yevhen Cherkes 2025</Copyright>
+		<PackageReadmeFile>Readme.md</PackageReadmeFile>
+		<PackageProjectUrl>https://github.com/Raffinert/Raffinert.Spec</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/Raffinert/Raffinert.Spec</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageTags>specification template</PackageTags>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+		<Authors>Yevhen Cherkes</Authors>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+		<None Include=".\Readme.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+	</ItemGroup>
+
+</Project>

--- a/src/Raffinert.Spec.Analyzer/Readme.md
+++ b/src/Raffinert.Spec.Analyzer/Readme.md
@@ -1,0 +1,14 @@
+# SpecTemplate Analyzers
+
+This Roslyn analyzer package helps prevent runtime errors when using [`Raffinert.Spec`](https://github.com/Raffinert/Raffinert.Spec).
+
+## Purpose
+
+- Ensures correct usage of `SpecTemplate<TSample>.Adapt<TN>()` by validating that `TN` contains all required members from `TTemplate` at **compile-time** instead of failing at runtime.
+- Enforces correct usage of `SpecTemplate.Create(...)`, requiring the first argument to be an **anonymous type projection** (e.g., `p => new { p.Name }`) to prevent invalid expressions.
+
+By catching these issues early, this analyzer enhances code reliability and prevents unexpected failures when adapting specifications.
+
+## Repository
+
+For more details, visit [`Raffinert.Spec`](https://github.com/Raffinert/Raffinert.Spec).

--- a/src/Raffinert.Spec.Analyzer/SpecTemplateAdaptAnalyzer.cs
+++ b/src/Raffinert.Spec.Analyzer/SpecTemplateAdaptAnalyzer.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Raffinert.Spec.Analyzer;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class SpecTemplateAdaptAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor MissingMembersRule = new(
+        id: "SPEC001",
+        title: "Type Signature Validation Failed",
+        messageFormat: "Type '{0}' is missing required members {{ {1} }} for specification template.",
+        category: "Usage",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true
+    );
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(MissingMembersRule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocationExpr = (InvocationExpressionSyntax)context.Node;
+        var semanticModel = context.SemanticModel;
+
+        if (semanticModel.GetSymbolInfo(invocationExpr).Symbol is not IMethodSymbol methodSymbol)
+            return;
+
+        // Ensure it's a call to SpecTemplate<TSample, TTemplate>.Adapt<TN>()
+        if (methodSymbol.ContainingType.Name != "SpecTemplate" || methodSymbol.Name != "Adapt")
+            return;
+
+        // Extract TTemplate and TN
+        var tTemplate = methodSymbol.ContainingType.TypeArguments[1];
+        
+        if (!tTemplate.IsAnonymousType)
+            return; // Ignore if it's not an anonymous type
+
+        var tN = methodSymbol.TypeArguments[0];
+
+        var missingMembers = tTemplate.GetMembers()
+            .OfType<IPropertySymbol>()
+            .Where(prop => !tN.GetMembers().OfType<IPropertySymbol>()
+                .Any(tnProp => tnProp.Name == prop.Name &&
+                               tnProp.Type.Equals(prop.Type, SymbolEqualityComparer.Default)))
+            .Select(prop => prop.Name)
+            .ToList();
+
+        if (missingMembers.Count <= 0)
+        {
+            return;
+        }
+
+        var diagnostic = Diagnostic.Create(
+            MissingMembersRule,
+            invocationExpr.GetLocation(),
+            tN.Name, string.Join(", ", missingMembers));
+
+        context.ReportDiagnostic(diagnostic);
+    }
+}

--- a/src/Raffinert.Spec.Analyzer/SpecTemplateCreateAnalyzer.cs
+++ b/src/Raffinert.Spec.Analyzer/SpecTemplateCreateAnalyzer.cs
@@ -1,0 +1,61 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Raffinert.Spec.Analyzer
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SpecTemplateCreateAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor InvalidTemplateUsageRule = new(
+            id: "SPEC002",
+            title: "Invalid SpecTemplate Usage",
+            messageFormat: "The first argument of SpecTemplate.Create must be an anonymous type projection (e.g., 'p => new { p.Name }').",
+            category: "Usage",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true
+        );
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(InvalidTemplateUsageRule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        }
+
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            var invocationExpr = (InvocationExpressionSyntax)context.Node;
+            var semanticModel = context.SemanticModel;
+
+            if (semanticModel.GetSymbolInfo(invocationExpr).Symbol is not IMethodSymbol methodSymbol)
+                return;
+
+            if (methodSymbol.ContainingType.Name != "SpecTemplate" || methodSymbol.Name != "Create")
+                return;
+
+            if (invocationExpr.ArgumentList.Arguments.Count < 2)
+                return;
+
+            var firstArgExpression = invocationExpr.ArgumentList.Arguments[0].Expression;
+
+            if (firstArgExpression is not LambdaExpressionSyntax lambdaExpr)
+                return;
+
+            if (lambdaExpr.Body is not AnonymousObjectCreationExpressionSyntax)
+            {
+                var diagnostic = Diagnostic.Create(
+                    InvalidTemplateUsageRule,
+                    firstArgExpression.GetLocation()
+                );
+
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}

--- a/src/Raffinert.Spec/Raffinert.Spec.csproj
+++ b/src/Raffinert.Spec/Raffinert.Spec.csproj
@@ -5,12 +5,12 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<Version>1.7.0</Version>
+	<Version>1.7.1</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<LangVersion>latest</LangVersion>
 	<AssemblyName>Raffinert.Spec</AssemblyName>
-	<AssemblyVersion>1.7.0</AssemblyVersion>
-	<FileVersion>1.7.0</FileVersion>
+	<AssemblyVersion>1.7.1</AssemblyVersion>
+	<FileVersion>1.7.1</FileVersion>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<Copyright>Copyright $([System.DateTime]::Now.Year) Yevhen Cherkes</Copyright>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/tests/Raffinert.Spec.Analyzer.Test/Raffinert.Spec.Analyzer.Test.csproj
+++ b/tests/Raffinert.Spec.Analyzer.Test/Raffinert.Spec.Analyzer.Test.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest" Version="1.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Raffinert.Spec.Analyzer\Raffinert.Spec.Analyzer.csproj" />
+    <ProjectReference Include="..\..\src\Raffinert.Spec\Raffinert.Spec.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Raffinert.Spec.Analyzer.Test/SpecTemplateAdaptAnalyzerUnitTest.cs
+++ b/tests/Raffinert.Spec.Analyzer.Test/SpecTemplateAdaptAnalyzerUnitTest.cs
@@ -1,0 +1,64 @@
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifyCS = Raffinert.Spec.Analyzer.Test.Verifiers.CSharpAnalyzerVerifier<Raffinert.Spec.Analyzer.SpecTemplateAdaptAnalyzer>;
+
+namespace Raffinert.Spec.Analyzer.Test
+{
+    [TestClass]
+    public class SpecTemplateAdaptAnalyzerUnitTest
+    {
+        //No diagnostics expected to show up
+        [TestMethod]
+        public async Task NoDiagnostics()
+        {
+            var test = @"";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [TestMethod]
+        public async Task CategoryHasMissingMembers()
+        {
+            var test = """
+                       using System;
+                       using System.Collections.Generic;
+                       using Raffinert.Spec;
+                       
+                       class Program
+                       {
+                           static void Main()
+                           {
+                               var bananaStringSpec = Spec<string>.Create(n => n == "Banana");
+                       
+                               var specTemplate = SpecTemplate<Product>.Create(
+                                   p => new { p.Name, p.Id },
+                                   arg => bananaStringSpec.IsSatisfiedBy(arg.Name) && arg.Id > 0);
+                       
+                               var categorySpec = specTemplate.Adapt<Category>("cat");
+                               var productSpec = specTemplate.Adapt<Product>("prod");
+                       
+                               Console.WriteLine("Specifications created successfully.");
+                           }
+                       }
+                       
+                       public class Product
+                       {
+                           public int Id { get; set; }
+                           public string Name { get; set; }
+                           public decimal Price { get; set; }
+                           public int CategoryId { get; set; }
+                           public Category Category { get; set; }
+                       }
+                       
+                       public class Category
+                       {
+                           public string Name { get; set; }
+                           public ICollection<Product> Products { get; set; } = new List<Product>();
+                       }
+                       """;
+
+            var expected = VerifyCS.Diagnostic("SPEC001").WithSpan(15, 28, 15, 63).WithArguments("Category", "Id");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+    }
+}

--- a/tests/Raffinert.Spec.Analyzer.Test/SpecTemplateCreateAnalyzerUnitTest.cs
+++ b/tests/Raffinert.Spec.Analyzer.Test/SpecTemplateCreateAnalyzerUnitTest.cs
@@ -1,0 +1,67 @@
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifyCS = Raffinert.Spec.Analyzer.Test.Verifiers.CSharpAnalyzerVerifier<Raffinert.Spec.Analyzer.SpecTemplateCreateAnalyzer>;
+
+namespace Raffinert.Spec.Analyzer.Test
+{
+    [TestClass]
+    public class SpecTemplateCreateAnalyzerUnitTest
+    {
+        //No diagnostics expected to show up
+        [TestMethod]
+        public async Task NoDiagnostics()
+        {
+            var test = @"";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [TestMethod]
+        public async Task WrongSpecTemplateConfiguration()
+        {
+            var test = """
+                       using System;
+                       using System.Collections.Generic;
+                       using Raffinert.Spec;
+
+                       class Program
+                       {
+                           static void Main()
+                           {
+                               var bananaStringSpec = Spec<string>.Create(n => n == "Banana");
+                       
+                               var specTemplate = SpecTemplate<Product>.Create(
+                                   p => p.Name,
+                                   arg => bananaStringSpec.IsSatisfiedBy(arg));
+                       
+                               var categorySpec = specTemplate.Adapt<Category>("cat");
+                               var productSpec = specTemplate.Adapt<Product>("prod");
+                       
+                               Console.WriteLine("Specifications created successfully.");
+                           }
+                       }
+
+                       public class Product
+                       {
+                           public int Id { get; set; }
+                           public string Name { get; set; }
+                           public decimal Price { get; set; }
+                           public int CategoryId { get; set; }
+                           public Category Category { get; set; }
+                       }
+
+                       public class Category
+                       {
+                           public string Name { get; set; }
+                           public ICollection<Product> Products { get; set; } = new List<Product>();
+                       }
+                       """;
+
+            var expected = VerifyCS.Diagnostic("SPEC002")
+                .WithSpan(12, 13, 12, 24)
+                .WithMessage("The first argument of SpecTemplate.Create must be an anonymous type projection (e.g., 'p => new { p.Name }').");
+
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+    }
+}

--- a/tests/Raffinert.Spec.Analyzer.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
+++ b/tests/Raffinert.Spec.Analyzer.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace Raffinert.Spec.Analyzer.Test.Verifiers
+{
+    public static partial class CSharpAnalyzerVerifier<TAnalyzer>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        public class Test : CSharpAnalyzerTest<TAnalyzer, MSTestVerifier>
+        {
+            public Test()
+            {
+                SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                        compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
+                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
+
+                    return solution;
+                });
+            }
+        }
+    }
+}

--- a/tests/Raffinert.Spec.Analyzer.Test/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/tests/Raffinert.Spec.Analyzer.Test/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace Raffinert.Spec.Analyzer.Test.Verifiers
+{
+    public static partial class CSharpAnalyzerVerifier<TAnalyzer>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic()"/>
+        public static DiagnosticResult Diagnostic()
+            => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic();
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(string)"/>
+        public static DiagnosticResult Diagnostic(string diagnosticId)
+            => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic(diagnosticId);
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+            => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic(descriptor);
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
+        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new Test
+            {
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalReferences =
+                    {
+                        MetadataReference.CreateFromFile(typeof(SpecTemplate<>).Assembly.Location)
+                    }
+                },
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/tests/Raffinert.Spec.Analyzer.Test/Verifiers/CSharpVerifierHelper.cs
+++ b/tests/Raffinert.Spec.Analyzer.Test/Verifiers/CSharpVerifierHelper.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Raffinert.Spec.Analyzer.Test.Verifiers
+{
+    internal static class CSharpVerifierHelper
+    {
+        /// <summary>
+        /// By default, the compiler reports diagnostics for nullable reference types at
+        /// <see cref="DiagnosticSeverity.Warning"/>, and the analyzer test framework defaults to only validating
+        /// diagnostics at <see cref="DiagnosticSeverity.Error"/>. This map contains all compiler diagnostic IDs
+        /// related to nullability mapped to <see cref="ReportDiagnostic.Error"/>, which is then used to enable all
+        /// of these warnings for default validation during analyzer and code fix tests.
+        /// </summary>
+        internal static ImmutableDictionary<string, ReportDiagnostic> NullableWarnings { get; } = GetNullableWarningsFromCompiler();
+
+        private static ImmutableDictionary<string, ReportDiagnostic> GetNullableWarningsFromCompiler()
+        {
+            string[] args = { "/warnaserror:nullable" };
+            var commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
+            var nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
+
+            // Workaround for https://github.com/dotnet/roslyn/issues/41610
+            nullableWarnings = nullableWarnings
+                .SetItem("CS8632", ReportDiagnostic.Error)
+                .SetItem("CS8669", ReportDiagnostic.Error);
+
+            return nullableWarnings;
+        }
+    }
+}

--- a/tests/Raffinert.Spec.IntegrationTests/SpecTemplatesTests.cs
+++ b/tests/Raffinert.Spec.IntegrationTests/SpecTemplatesTests.cs
@@ -12,9 +12,7 @@ public class SpecTemplatesTests(ProductFilterFixture fixture) : IClassFixture<Pr
     public void SingleLineTemplate()
     {
         // Arrange
-        var specTemplate = SpecTemplate<Product>.Create(
-            p => p.Name, 
-            arg => arg == "Banana");
+        var specTemplate = SpecTemplate<Product>.Create(p => new { p.Name }, arg => arg.Name == "Banana");
 
         var categorySpec = specTemplate.Adapt<Category>();
         var productSpec = specTemplate.Adapt<Product>();


### PR DESCRIPTION
1. Add Raffinert.Spec.Analyzer which helps avoid runtime errors with SpecTemplate
2. Keep the only way to define SpecTemplate - via Anonymous type creation